### PR TITLE
chore: replace old partner teams with new ones (Wave 2)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-*   @googleapis/llama-index-spanner
+*   @googleapis/llama-index-spanner-team

--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 assign_issues:
-  - googleapis/llama-index-spanner
+  - googleapis/llama-index-spanner-team
 assign_prs:
-  - googleapis/llama-index-spanner
+  - googleapis/llama-index-spanner-team

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,13 +1,13 @@
 {
     "name": "llama-index-spanner",
     "name_pretty": "Cloud Spanner for LlamaIndex - Python",
-    "issue_tracker": "https://github.com/googleapis/llama-index-spanner-python/issues",
-    "client_documentation": "https://github.com/googleapis/llama-index-spanner-python/tree/main/docs",
+    "issue_tracker": "https://github.com/googleapis/llama-index-spanner-team-python/issues",
+    "client_documentation": "https://github.com/googleapis/llama-index-spanner-team-python/tree/main/docs",
     "release_level": "preview",
     "language": "python",
     "library_type": "OTHER",
-    "repo": "googleapis/llama-index-spanner-python",
+    "repo": "googleapis/llama-index-spanner-team-python",
     "distribution_name": "llama-index-spanner",
     "requires_billing": true,
-    "codeowner_team": "@googleapis/llama-index-spanner"
+    "codeowner_team": "@googleapis/llama-index-spanner-team"
 }


### PR DESCRIPTION
Replacing old partner teams with new ones as part of Wave 2 migration. b/478003109