### PR TITLE
Fix: correct package name in graph_retriever notebook

### DIFF
--- a/docs/graph_retriever.ipynb
+++ b/docs/graph_retriever.ipynb
@@ -40,7 +40,7 @@
    },
    "source": [
     "### 🦜🔗 Library Installation\n",
-    "The integration lives in its own `llama-index-google-spanner` package, so we need to install it."
+    "The integration lives in its own `llama-index-spanner` package, so we need to install it."
    ]
   },
   {
@@ -51,7 +51,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install --upgrade --quiet llama-index-google-spanner json-repair pyvis"
+    "%pip install --upgrade --quiet llama-index-spanner json-repair pyvis"
    ]
   },
   {
@@ -155,7 +155,7 @@
    },
    "source": [
     "### 💡 API Enablement\n",
-    "The `llama-index-google-spanner` package requires that you [enable the Spanner API](https://console.cloud.google.com/flows/enableapi?apiid=spanner.googleapis.com) in your Google Cloud Project."
+    "The `llama-index-spanner` package requires that you [enable the Spanner API](https://console.cloud.google.com/flows/enableapi?apiid=spanner.googleapis.com) in your Google Cloud Project."
    ]
   },
   {


### PR DESCRIPTION
The notebook references `llama-index-google-spanner` but the published PyPI package is `llama-index-spanner`. This fixes the install command and inline references.